### PR TITLE
Add vitest tests for apiRequest

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx,json,css,scss,md}\"",
-    "format:check": "prettier --check \"src/**/*.{js,jsx,ts,tsx,json,css,scss,md}\""
+    "format:check": "prettier --check \"src/**/*.{js,jsx,ts,tsx,json,css,scss,md}\"",
+    "test": "vitest"
   },
   "dependencies": {
     "@chakra-ui/react": "^3.14.2",
@@ -35,6 +36,7 @@
     "eslint-plugin-react-hooks": "^5.1.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^15.15.0",
+    "vitest": "^1.5.0",
     "prettier": "^3.5.3",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.24.1",

--- a/src/services/spotifyApi.test.ts
+++ b/src/services/spotifyApi.test.ts
@@ -1,0 +1,37 @@
+import * as spotify from './spotifyApi';
+import { vi, describe, expect, it, beforeEach, afterEach } from 'vitest';
+
+describe('apiRequest', () => {
+  beforeEach(() => {
+    vi.spyOn(spotify, 'getValidToken').mockResolvedValue('token');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns null for 204 responses', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 204,
+      json: vi.fn(),
+    } as unknown as Response);
+    (global as any).fetch = fetchMock;
+
+    const result = await spotify.apiRequest('/test');
+    expect(result).toBeNull();
+  });
+
+  it('parses JSON for 200 responses', async () => {
+    const data = { foo: 'bar' };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue(data),
+    } as unknown as Response);
+    (global as any).fetch = fetchMock;
+
+    const result = await spotify.apiRequest<typeof data>('/test');
+    expect(result).toEqual(data);
+  });
+});

--- a/src/services/spotifyApi.ts
+++ b/src/services/spotifyApi.ts
@@ -164,7 +164,7 @@ export const getValidToken = async (): Promise<string> => {
 };
 
 // API request helper with automatic token handling
-const apiRequest = async <T, B extends Record<string, unknown> = Record<string, unknown>>(
+export const apiRequest = async <T, B extends Record<string, unknown> = Record<string, unknown>>(
   endpoint: string,
   method: string = 'GET',
   body?: B
@@ -187,6 +187,10 @@ const apiRequest = async <T, B extends Record<string, unknown> = Record<string, 
 
   if (!response.ok) {
     throw new Error(`API request failed: ${response.statusText}`);
+  }
+
+  if (response.status === 204) {
+    return null as unknown as T;
   }
 
   return (await response.json()) as T;


### PR DESCRIPTION
## Summary
- add `vitest` dev dependency and npm test script
- handle 204 responses in `apiRequest`
- expose `apiRequest` for testing
- add unit tests for `apiRequest`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a4d31219c83229fe2240cc8973940