### PR TITLE
Handle Spotify no-content responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "vitest",
     "preview": "vite preview",
     "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx,json,css,scss,md}\"",
     "format:check": "prettier --check \"src/**/*.{js,jsx,ts,tsx,json,css,scss,md}\""
@@ -38,7 +39,13 @@
     "prettier": "^3.5.3",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.24.1",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "vitest": "^1.5.0",
+    "jsdom": "^24.0.0",
+    "@testing-library/dom": "^9.0.0",
+    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.4.3"
   },
   "packageManager": "pnpm@10.6.5+sha512.cdf928fca20832cd59ec53826492b7dc25dc524d4370b6b4adbf65803d32efaa6c1c88147c0ae4e8d579a6c9eec715757b50d4fa35eea179d868eada4ed043af"
 }

--- a/setup-test.ts
+++ b/setup-test.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/src/hooks/useSpotifyData.ts
+++ b/src/hooks/useSpotifyData.ts
@@ -7,11 +7,11 @@ import {
   getTopTracks,
   getUserProfile,
 } from '@/services/spotifyApi';
-import { TimeRange } from '@/types/spotify';
+import { TimeRange, CurrentlyPlayingResponse } from '@/types/spotify';
 
 // Hook for fetching currently playing track
 export const useCurrentlyPlaying = () => {
-  return useQuery({
+  return useQuery<CurrentlyPlayingResponse | null>({
     queryKey: ['currentlyPlaying'],
     queryFn: getCurrentlyPlaying,
     refetchInterval: 30000, // Refetch every 30 seconds

--- a/src/services/__tests__/spotifyApi.test.ts
+++ b/src/services/__tests__/spotifyApi.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import * as spotifyApi from '../spotifyApi';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('getCurrentlyPlaying', () => {
+  it('returns null when response status is 204', async () => {
+    vi.spyOn(spotifyApi, 'getValidToken').mockResolvedValue('token');
+    global.fetch = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+
+    const result = await spotifyApi.getCurrentlyPlaying();
+    expect(result).toBeNull();
+  });
+
+  it('returns null when response status is 205', async () => {
+    vi.spyOn(spotifyApi, 'getValidToken').mockResolvedValue('token');
+    global.fetch = vi.fn().mockResolvedValue(new Response(null, { status: 205 }));
+
+    const result = await spotifyApi.getCurrentlyPlaying();
+    expect(result).toBeNull();
+  });
+});

--- a/src/services/spotifyApi.ts
+++ b/src/services/spotifyApi.ts
@@ -188,6 +188,9 @@ const apiRequest = async <T, B extends Record<string, unknown> = Record<string, 
   if (!response.ok) {
     throw new Error(`API request failed: ${response.statusText}`);
   }
+  if (response.status === 204 || response.status === 205) {
+    return null as unknown as T;
+  }
 
   return (await response.json()) as T;
 };
@@ -195,8 +198,8 @@ const apiRequest = async <T, B extends Record<string, unknown> = Record<string, 
 // API Endpoints
 
 // Get currently playing track
-export const getCurrentlyPlaying = (): Promise<CurrentlyPlayingResponse> => {
-  return apiRequest<CurrentlyPlayingResponse>('/me/player/currently-playing');
+export const getCurrentlyPlaying = (): Promise<CurrentlyPlayingResponse | null> => {
+  return apiRequest<CurrentlyPlayingResponse | null>('/me/player/currently-playing');
 };
 
 // Get playback queue

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import { fileURLToPath } from 'url';
 import path from 'path';
@@ -14,5 +14,10 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, './src'),
     },
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './setup-test.ts',
   },
 });


### PR DESCRIPTION
## Summary
- add Vitest config and test script
- return `null` for 204/205 responses in the API helper
- update `getCurrentlyPlaying` and hooks to allow `null`
- add unit test for empty `currently-playing` response

## Testing
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: cannot find modules)*
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a4d2cffbc8322a0d07a5d7aa2a54b